### PR TITLE
Adding support for multiple pyopencl devices

### DIFF
--- a/src/nanopyx/liquid/__init__.py
+++ b/src/nanopyx/liquid/__init__.py
@@ -17,7 +17,7 @@ import warnings
 import platform
 
 from .__njit__ import njit_works
-from .__opencl__ import cl, cl_array, cl_ctx, cl_queue, opencl_works, print_opencl_info
+from .__opencl__ import cl, cl_array, opencl_works, print_opencl_info, devices
 from ._le_interpolation_bicubic import ShiftAndMagnify as BCShiftAndMagnify
 from ._le_interpolation_bicubic import ShiftScaleRotate as BCShiftScaleRotate
 from ._le_interpolation_catmull_rom import ShiftAndMagnify as CRShiftAndMagnify

--- a/src/nanopyx/liquid/_le_interpolation_bicubic.pyx
+++ b/src/nanopyx/liquid/_le_interpolation_bicubic.pyx
@@ -10,7 +10,7 @@ from libc.math cimport cos, sin
 
 from .__interpolation_tools__ import check_image, value2array
 from .__liquid_engine__ import LiquidEngine
-from .__opencl__ import cl, cl_array, cl_ctx, cl_queue
+from .__opencl__ import cl, cl_array
 
 
 cdef extern from "_c_interpolation_bicubic.h":
@@ -93,13 +93,18 @@ class ShiftAndMagnify(LiquidEngine):
 
     # tag-copy: _le_interpolation_nearest_neighbor.ShiftAndMagnify._run_opencl; replace("nearest_neighbor", "bicubic")
     @LiquidEngine._logger(logger)
-    def _run_opencl(self, image, shift_row, shift_col, float magnification_row, float magnification_col) -> np.ndarray:
+    def _run_opencl(self, image, shift_row, shift_col, float magnification_row, float magnification_col, dict device) -> np.ndarray:
+
+        # QUEUE AND CONTEXT
+        cl_ctx = cl.Context([device['device']])
+        cl_queue = cl.CommandQueue(cl_ctx)
+
         # Swap row and columns because opencl is strange and stores the
         # array in a buffer in fortran ordering despite the original
         # numpy array being in C order.
         image = np.ascontiguousarray(np.swapaxes(image, 1, 2), dtype=np.float32)
 
-        code = self._get_cl_code("_le_interpolation_bicubic_.cl")
+        code = self._get_cl_code("_le_interpolation_bicubic_.cl", device['DP'])
 
         cdef int nFrames = image.shape[0]
         cdef int rowsM = <int>(image.shape[1] * magnification_row)
@@ -337,14 +342,18 @@ class ShiftScaleRotate(LiquidEngine):
 
     # tag-copy: _le_interpolation_nearest_neighbor.ShiftScaleRotate._run_opencl; replace("nearest_neighbor", "bicubic")
     @LiquidEngine._logger(logger)
-    def _run_opencl(self, image, shift_row, shift_col, float scale_row, float scale_col, float angle) -> np.ndarray:
+    def _run_opencl(self, image, shift_row, shift_col, float scale_row, float scale_col, float angle, dict device) -> np.ndarray:
+
+        # QUEUE AND CONTEXT
+        cl_ctx = cl.Context([device['device']])
+        cl_queue = cl.CommandQueue(cl_ctx)
 
         # Swap row and columns because opencl is strange and stores the
         # array in a buffer in fortran ordering despite the original
         # numpy array being in C order.
         image = np.ascontiguousarray(np.swapaxes(image, 1, 2), dtype=np.float32)
 
-        code = self._get_cl_code("_le_interpolation_bicubic_.cl")
+        code = self._get_cl_code("_le_interpolation_bicubic_.cl", device['DP'])
 
         cdef int nFrames = image.shape[0]
         cdef int rowsM = image.shape[1]

--- a/src/nanopyx/liquid/_le_interpolation_lanczos.pyx
+++ b/src/nanopyx/liquid/_le_interpolation_lanczos.pyx
@@ -10,7 +10,7 @@ from libc.math cimport cos, sin
 
 from .__interpolation_tools__ import check_image, value2array
 from .__liquid_engine__ import LiquidEngine
-from .__opencl__ import cl, cl_array, cl_ctx, cl_queue
+from .__opencl__ import cl, cl_array
 
 
 cdef extern from "_c_interpolation_catmull_rom.h":
@@ -93,13 +93,18 @@ class ShiftAndMagnify(LiquidEngine):
 
     # tag-copy: _le_interpolation_nearest_neighbor.ShiftAndMagnify._run_opencl; replace("nearest_neighbor", "lanczos")
     @LiquidEngine._logger(logger)
-    def _run_opencl(self, image, shift_row, shift_col, float magnification_row, float magnification_col) -> np.ndarray:
+    def _run_opencl(self, image, shift_row, shift_col, float magnification_row, float magnification_col, dict device) -> np.ndarray:
+
+        # QUEUE AND CONTEXT
+        cl_ctx = cl.Context([device['device']])
+        cl_queue = cl.CommandQueue(cl_ctx)
+
         # Swap row and columns because opencl is strange and stores the
         # array in a buffer in fortran ordering despite the original
         # numpy array being in C order.
         image = np.ascontiguousarray(np.swapaxes(image, 1, 2), dtype=np.float32)
 
-        code = self._get_cl_code("_le_interpolation_lanczos_.cl")
+        code = self._get_cl_code("_le_interpolation_lanczos_.cl", device['DP'])
 
         cdef int nFrames = image.shape[0]
         cdef int rowsM = <int>(image.shape[1] * magnification_row)
@@ -337,14 +342,18 @@ class ShiftScaleRotate(LiquidEngine):
 
     # tag-copy: _le_interpolation_nearest_neighbor.ShiftScaleRotate._run_opencl; replace("nearest_neighbor", "lanczos")
     @LiquidEngine._logger(logger)
-    def _run_opencl(self, image, shift_row, shift_col, float scale_row, float scale_col, float angle) -> np.ndarray:
+    def _run_opencl(self, image, shift_row, shift_col, float scale_row, float scale_col, float angle, dict device) -> np.ndarray:
+
+        # QUEUE AND CONTEXT
+        cl_ctx = cl.Context([device['device']])
+        cl_queue = cl.CommandQueue(cl_ctx)
 
         # Swap row and columns because opencl is strange and stores the
         # array in a buffer in fortran ordering despite the original
         # numpy array being in C order.
         image = np.ascontiguousarray(np.swapaxes(image, 1, 2), dtype=np.float32)
 
-        code = self._get_cl_code("_le_interpolation_lanczos_.cl")
+        code = self._get_cl_code("_le_interpolation_lanczos_.cl", device['DP'])
 
         cdef int nFrames = image.shape[0]
         cdef int rowsM = image.shape[1]

--- a/src/nanopyx/liquid/_le_mandelbrot_benchmark.pyx
+++ b/src/nanopyx/liquid/_le_mandelbrot_benchmark.pyx
@@ -7,7 +7,7 @@ cimport numpy as np
 from cython.parallel import prange
 
 from .__liquid_engine__ import LiquidEngine
-from .__opencl__ import cl, cl_array, cl_ctx, cl_queue
+from .__opencl__ import cl, cl_array
 from ._le_mandelbrot_benchmark_ import mandelbrot as _py_mandelbrot
 from ._le_mandelbrot_benchmark_ import njit_mandelbrot as _njit_mandelbrot
 
@@ -48,8 +48,13 @@ class MandelbrotBenchmark(LiquidEngine):
     def benchmark(self, int size, float r_start=-1.5, float r_end=0.5, float c_start=-1, float c_end=1):
         return super().benchmark(size, r_start, r_end, c_start, c_end)
 
-    def _run_opencl(self, int size, float r_start, float r_end, float c_start, float c_end) -> np.ndarray:
-        code = self._get_cl_code("_le_mandelbrot_benchmark_.cl")
+    def _run_opencl(self, int size, float r_start, float r_end, float c_start, float c_end, dict device) -> np.ndarray:
+
+        # QUEUE AND CONTEXT
+        cl_ctx = cl.Context([device['device']])
+        cl_queue = cl.CommandQueue(cl_ctx)
+
+        code = self._get_cl_code("_le_mandelbrot_benchmark_.cl", device['DP'])
 
         # Create array for mandelbrot set
         im_mandelbrot = cl_array.zeros(cl_queue, (size, size), dtype=np.int32)

--- a/tests/notebooks/le_interpolation_nearest_neighbor.ipynb
+++ b/tests/notebooks/le_interpolation_nearest_neighbor.ipynb
@@ -157,6 +157,7 @@
    },
    "outputs": [],
    "source": [
+    "\"\"\"\n",
     "from nanopyx.core.generate.noise_add_simplex import get_simplex_noise\n",
     "from nanopyx.liquid._le_interpolation_nearest_neighbor import PolarTransform\n",
     "import numpy as np\n",
@@ -187,7 +188,8 @@
     "    ax.imshow(images[i][-1], cmap=\"hot\")\n",
     "    ax.set_title(titles[i])\n",
     "    ax.axis(\"off\")\n",
-    "plt.show()\n"
+    "plt.show()\n",
+    "\"\"\"\n"
    ]
   },
   {
@@ -198,6 +200,7 @@
    },
    "outputs": [],
    "source": [
+    "\"\"\"\n",
     "from skimage.transform import warp_polar\n",
     "from matplotlib import pyplot as plt\n",
     "import seaborn as sns\n",
@@ -206,7 +209,8 @@
     "axes[1].imshow(warp_polar(image_og[-1], output_shape=(100,512)),cmap='hot')\n",
     "axes[2].imshow(warp_polar(image_og[-1], output_shape=(100,512), scaling='log'),cmap='hot')\n",
     "axes[0].imshow(image_og[-1], cmap='hot')\n",
-    "plt.show()"
+    "plt.show()\n",
+    "\"\"\""
    ]
   },
   {


### PR DESCRIPTION
 - Multiple devices are listed as different run types in the liquid engine base class.
 - Multiple devices are benchmarked against each other but share the same pyopencl implementation.