### PR TITLE
Make code snippet copy&pastable

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,9 @@ if you found this work useful, please cite: [preprint](https://www.biorxiv.org/c
 
 NanoPyx is also available as a napari plugin, which can be installed via pip:
 
-```pip install napari-nanopyx```
+```
+pip install napari-nanopyx
+```
 
 ## Installation
 


### PR DESCRIPTION
This adds a copy button next to the code snippet on the github page.