### PR TITLE
Fix dtype mismatch in resolution analyses

### DIFF
--- a/src/nanopyx/core/analysis/decorr.pyx
+++ b/src/nanopyx/core/analysis/decorr.pyx
@@ -302,7 +302,7 @@ cdef class DecorrAnalysis:
                 blurred = np.copy(self.img_ref)
                 blurred = gaussian_filter(blurred, sig)
                 blurred = np.copy(self.img_ref) - blurred
-                fft = np.fft.fftshift(np.fft.fft2(blurred))
+                fft = np.fft.fftshift(np.fft.fft2(blurred)).astype(np.complex64)
                 fft_real = np.real(fft).astype(np.float32)
                 fft_imag = np.imag(fft).astype(np.float32)
                 normalized_fft = _normalizeFFT(fft_real, fft_imag)
@@ -416,7 +416,7 @@ cdef class DecorrAnalysis:
         img_f = _apodize_edges(img_f)
         temp = self._get_preprocessed_image(img_f)
         self.img_ref = np.copy(temp)
-        img_fft = np.fft.fftshift(np.fft.fft2(temp))
+        img_fft = np.fft.fftshift(np.fft.fft2(temp)).astype(np.complex64)
         fft_real = np.real(img_fft).astype(np.float32)
         fft_imag = np.imag(img_fft).astype(np.float32)
         fft_real[fft_real.shape[0]//2, fft_real.shape[1]//2] = 0

--- a/src/nanopyx/core/analysis/frc.pyx
+++ b/src/nanopyx/core/analysis/frc.pyx
@@ -170,7 +170,7 @@ cdef class FIRECalculator:
         return results
 
     def calculate_fft(self, img: np.ndarray):
-        return np.fft.fftshift(np.fft.fft2(img))
+        return np.fft.fftshift(np.fft.fft2(img)).astype(np.complex64)
 
     cdef _calculate_frc_curve(self, float[:, :] img1, float[:, :] img2):
 


### PR DESCRIPTION
There is an issue in resolution analyses (decorrelation and FRC), where Cython `cdef complex[:, :]` defaults to double complex (`complex128`), but `np.fft.fft2()` on `float32` input returns `complex64`.

Actually, current tests fail on `main`, e.g.

```bash
pytest tests/test_decorr_analysis.py
pytest tests/test_package_level_calls.py::test_package_decorr
pytest tests/test_package_level_calls.py::test_package_frc
```

each raise 

```
ValueError: Buffer dtype mismatch, expected 'double complex' but got 'complex float'
```

Explicitly specifying `float complex` solves the issue and all three tests pass.